### PR TITLE
Make ECS deployment step non-blocking

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -97,11 +97,12 @@ jobs:
 
       - name: Force ECS Deployment (Fallback)
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        continue-on-error: true
         run: |
           aws ecs update-service \
             --cluster options-app-cluster \
             --service options-app-service \
             --force-new-deployment \
-            --region us-east-1
-
-          echo "::notice title=ECS Deployment::Forced new deployment of options-app-service"
+            --region us-east-1 \
+            && echo "::notice title=ECS Deployment::Forced new deployment of options-app-service" \
+            || echo "::warning title=ECS Deployment::Could not force ECS deployment (missing permissions). Terraform Cloud will handle deployment."


### PR DESCRIPTION
The ECS force deployment is a fallback mechanism. If the IAM role lacks ecs:UpdateService permission, the step will now show a warning instead of failing the entire workflow. Terraform Cloud will handle the deployment.