### PR TITLE
Optimize ALB health checks for Python 3.14 startup time

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -19,5 +19,5 @@ COPY . /app/
 # Expose the application port
 EXPOSE 5000
 
-# Use uv to run the application, which automatically uses the project's virtual environment
+# Use uv to run the application (rebuilds venv at startup but ensures correct platform)
 CMD ["uv", "run", "gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "app:app"]

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -83,10 +83,10 @@ resource "aws_lb_target_group" "flask_tg_ip" {
   target_type = "ip"
 
   health_check {
-    healthy_threshold   = 5
+    healthy_threshold   = 2  # Reduced from 5 for faster health checks (2 × 10s = 20s to become healthy)
     unhealthy_threshold = 2
-    timeout             = 3
-    interval            = 30
+    timeout             = 5  # Increased from 3 to allow for app startup time
+    interval            = 10 # Reduced from 30 for faster health check cycles
     path                = "/health"
     protocol            = "HTTP"
   }


### PR DESCRIPTION
## Problem
Tasks with Python 3.14 were failing health checks because:
1. `uv run` rebuilds the venv at container startup (takes 5-6 seconds)
2. ALB health checks required 5 consecutive successes at 30s intervals (150s total)
3. Tasks were being stopped before becoming healthy

## Solution
**Optimized ALB health check configuration:**
- `healthy_threshold`: 5 → 2 (becomes healthy in 20s instead of 150s)
- `timeout`: 3s → 5s (allows for app startup time)  
- `interval`: 30s → 10s (faster health check cycles)

## Why `uv run`?
Keeping `uv run` (despite 5-6s startup delay) because:
- Ensures packages are built for correct architecture (linux/amd64)
- Avoids "invalid ELF header" errors from cross-platform builds
- More reliable than trying to pre-build venv with correct binaries

## Testing
After merge, CI/CD will:
1. Build image on AMD64 GitHub Actions runner
2. Push to ECR
3. Trigger Terraform Cloud (needs manual approval)
4. Deploy with new health check settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)