### PR TITLE
Increase unhealthy threshold to tolerate startup delays

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -19,5 +19,5 @@ COPY . /app/
 # Expose the application port
 EXPOSE 5000
 
-# Use uv to run the application, which automatically uses the project's virtual environment
+# Use uv to run the application (rebuilds venv at startup but ensures correct platform)
 CMD ["uv", "run", "gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "app:app"]

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -84,7 +84,7 @@ resource "aws_lb_target_group" "flask_tg_ip" {
 
   health_check {
     healthy_threshold   = 2  # Reduced from 5 for faster health checks (2 × 10s = 20s to become healthy)
-    unhealthy_threshold = 2
+    unhealthy_threshold = 3  # Increased to 3 to tolerate initial startup failures
     timeout             = 5  # Increased from 3 to allow for app startup time
     interval            = 10 # Reduced from 30 for faster health check cycles
     path                = "/health"

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -83,10 +83,10 @@ resource "aws_lb_target_group" "flask_tg_ip" {
   target_type = "ip"
 
   health_check {
-    healthy_threshold   = 5
+    healthy_threshold   = 2  # Reduced from 5 for faster health checks (2 × 10s = 20s to become healthy)
     unhealthy_threshold = 2
-    timeout             = 3
-    interval            = 30
+    timeout             = 5  # Increased from 3 to allow for app startup time
+    interval            = 10 # Reduced from 30 for faster health check cycles
     path                = "/health"
     protocol            = "HTTP"
   }


### PR DESCRIPTION
Increased unhealthy_threshold from 2 to 3 to allow the first 2 health checks to fail during the 6-second app startup without immediately marking the task as unhealthy.