### PR TITLE
Add concurrent fetching, query params, breakeven display, and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,21 @@ The core pricing logic calculates annualized returns for options strategies:
 
 ### Data Fetching
 
-Uses yfinance with curl_cffi session impersonation to avoid rate limiting. The `get_current_price()` function fetches 1-minute interval data for the most recent price quote.
+Uses yfinance with curl_cffi session impersonation to avoid rate limiting. A single `curl_cffi` session is created per request and shared across `get_current_price()` and `fetch_and_calculate_option_returns()`. Option chains for all expiration dates are fetched concurrently using `ThreadPoolExecutor`.
+
+### Query Parameters
+
+The app supports both POST form submissions and GET query parameters. You can bookmark or share URLs with pre-filled parameters:
+
+```
+/?ticker=AAPL&return_filter=on&return_threshold=25&out_of_the_money=on
+```
+
+Available parameters:
+- `ticker` — Stock ticker symbol (required)
+- `return_filter` — Set to `on` to enable annualized return filtering
+- `return_threshold` — Minimum annualized return percentage (default 15.0, accepts decimals like 25.5)
+- `out_of_the_money` — Set to `on` to show only OTM options
 
 ### Filtering Options
 

--- a/README.md
+++ b/README.md
@@ -114,14 +114,33 @@ aws ecs update-service --cluster options-app-cluster --service options-app-servi
 ## Application Features
 
 - **Options Chain Analysis**: Fetches real-time option data for any stock ticker
+- **Concurrent Fetching**: Option chains for all expiration dates are fetched in parallel
 - **Dynamic Return Filter**: User-configurable annualized return threshold (default 15%)
 - **Strategy Calculations**:
   - Cash-secured puts annualized returns
   - Covered calls annualized returns
+  - Breakeven % for both strategies
 - **Responsive Design**: Pivot tables adapt to screen size with horizontal scrolling
 - **Filters**:
   - Annualized return threshold (customizable)
   - Out-of-the-money options only
+
+### Query Parameters
+
+The app supports GET query parameters, so you can bookmark or share URLs with pre-filled options:
+
+```
+/?ticker=AAPL&return_filter=on&return_threshold=25&out_of_the_money=on
+```
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `ticker` | Stock ticker symbol (required) | `AAPL` |
+| `return_filter` | Enable annualized return filtering | `on` |
+| `return_threshold` | Minimum annualized return % (default 15.0) | `25.5` |
+| `out_of_the_money` | Show only OTM options | `on` |
+
+The same parameters work via the web form (POST) or URL query string (GET).
 
 ## Technology Stack
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -19,5 +19,5 @@ COPY . /app/
 # Expose the application port
 EXPOSE 5000
 
-# Use uv to run the application, which automatically uses the project's virtual environment
+# Use uv to run the application (rebuilds venv at startup but ensures correct platform)
 CMD ["uv", "run", "gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "app:app"]

--- a/app/README.md
+++ b/app/README.md
@@ -59,7 +59,22 @@ app/
 - **Annualized Return Threshold**: User-configurable (default 15%)
 - **Out-of-the-Money Only**: Filter to show only OTM options
 
-### 4. Responsive UI
+### 4. Query Parameters
+
+Supports both POST form submissions and GET query parameters for bookmarkable/shareable URLs:
+
+```
+https://options.yuanhuang.info/?ticker=AAPL&return_filter=on&return_threshold=25&out_of_the_money=on
+```
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `ticker` | Stock ticker symbol (required) | `AAPL` |
+| `return_filter` | Enable annualized return filtering | `on` |
+| `return_threshold` | Minimum annualized return % (default 15.0) | `25.5` |
+| `out_of_the_money` | Show only OTM options | `on` |
+
+### 5. Responsive UI
 - Pivot tables with horizontal scrolling
 - Adapts to desktop and mobile screens
 - Bootstrap 4 styling with custom CSS

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -84,7 +84,7 @@ resource "aws_lb_target_group" "flask_tg_ip" {
 
   health_check {
     healthy_threshold   = 2  # Reduced from 5 for faster health checks (2 × 10s = 20s to become healthy)
-    unhealthy_threshold = 2
+    unhealthy_threshold = 3  # Increased to 3 to tolerate initial startup failures
     timeout             = 5  # Increased from 3 to allow for app startup time
     interval            = 10 # Reduced from 30 for faster health check cycles
     path                = "/health"

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -83,10 +83,10 @@ resource "aws_lb_target_group" "flask_tg_ip" {
   target_type = "ip"
 
   health_check {
-    healthy_threshold   = 5
+    healthy_threshold   = 2  # Reduced from 5 for faster health checks (2 × 10s = 20s to become healthy)
     unhealthy_threshold = 2
-    timeout             = 3
-    interval            = 30
+    timeout             = 5  # Increased from 3 to allow for app startup time
+    interval            = 10 # Reduced from 30 for faster health check cycles
     path                = "/health"
     protocol            = "HTTP"
   }


### PR DESCRIPTION
## Summary
- Fetch option chains concurrently with `ThreadPoolExecutor` for faster page loads
- Support GET query parameters for bookmarkable/shareable URLs (e.g. `/?ticker=AAPL&out_of_the_money=on`)
- Share `curl_cffi` session across price and option chain fetches for bot-detection bypass
- Display Breakeven % column in pivot tables alongside bid and annualized return
- Fix crash on empty ticker submission (`NoneType` has no attribute `upper`)
- Switch logging from DEBUG to INFO and replace `print()` with `logger.error()`
- Update READMEs and CLAUDE.md with query parameter docs and new features

## Test plan
- [ ] Submit empty ticker — should flash warning, not crash
- [ ] Submit valid ticker (e.g. AAPL) — results should load faster than before
- [ ] Verify Breakeven % column appears in both puts and calls tables
- [ ] Test GET query parameter: `/?ticker=AAPL&out_of_the_money=on`
- [ ] Verify health endpoint: `curl /health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)