### PR TITLE
Add port 3000 ingress rule to ECS security group for oura-sync app

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -13,6 +13,14 @@ resource "aws_security_group" "ecs_service_sg" {
     security_groups = [aws_security_group.alb_sg.id]
   }
 
+  ingress {
+    description     = "HTTP from ALB (oura-sync)"
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb_sg.id]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
- Add ingress rule allowing port 3000 from ALB to ECS
- Supports oura-sync application running on port 3000
- Existing Flask app on port 5000 remains unaffected